### PR TITLE
Add note to README about being built with Claude Opus 4.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,3 +105,7 @@ missile_command/
 - **HTML5 Canvas 2D** — 960×540 logical resolution, scales to fit any window
 - **Web Audio API** — procedural retro sound effects
 - **localStorage** — high score persistence
+
+## Built With AI
+
+This project was built with [Claude Opus 4.6](https://www.anthropic.com/claude) as an experiment using the Claude mobile app.


### PR DESCRIPTION
## Summary

- Adds a "Built With AI" section to the README noting the project was built with Claude Opus 4.6 as an experiment using the Claude mobile app

## Test plan

- [ ] Verify the new section appears at the bottom of the README on GitHub

https://claude.ai/code/session_01RtqanoCCTH8fxXsVR9sx5h