### PR TITLE
Add stacked missile sprites at each base

### DIFF
--- a/index.html
+++ b/index.html
@@ -375,10 +375,28 @@
                 ctx.lineTo(base.x + 10, base.y - base.height);
                 ctx.lineTo(base.x + base.width / 2, base.y);
                 ctx.closePath(); ctx.fill();
-                ctx.fillStyle = '#aaffaa';
-                const tw = 3, gap = 2, total = base.ammo * (tw + gap) - gap;
-                const sx = base.x - total / 2;
-                for (let i = 0; i < base.ammo; i++) ctx.fillRect(sx + i * (tw + gap), base.y - base.height - 8, tw, 5);
+                if (base.ammo > 0) {
+                    const mW = 3, mH = 10, sp = 5;
+                    const bc = Math.min(base.ammo, 5), tc = Math.max(0, base.ammo - 5);
+                    const bTW = bc * (mW + sp) - sp, bSX = base.x - bTW / 2, bY = base.y - 4;
+                    for (let i = 0; i < bc; i++) {
+                        const mx = bSX + i * (mW + sp);
+                        ctx.fillStyle = '#aaffaa'; ctx.fillRect(mx, bY - mH, mW, mH);
+                        ctx.fillStyle = '#ffffff'; ctx.beginPath();
+                        ctx.moveTo(mx, bY - mH); ctx.lineTo(mx + mW / 2, bY - mH - 3); ctx.lineTo(mx + mW, bY - mH);
+                        ctx.closePath(); ctx.fill();
+                    }
+                    if (tc > 0) {
+                        const tTW = tc * (mW + sp) - sp, tSX = base.x - tTW / 2, tY = bY - mH - 4;
+                        for (let i = 0; i < tc; i++) {
+                            const mx = tSX + i * (mW + sp);
+                            ctx.fillStyle = '#aaffaa'; ctx.fillRect(mx, tY - mH, mW, mH);
+                            ctx.fillStyle = '#ffffff'; ctx.beginPath();
+                            ctx.moveTo(mx, tY - mH); ctx.lineTo(mx + mW / 2, tY - mH - 3); ctx.lineTo(mx + mW, tY - mH);
+                            ctx.closePath(); ctx.fill();
+                        }
+                    }
+                }
             }
         }
         drawCities(cities) {

--- a/js/renderer.js
+++ b/js/renderer.js
@@ -88,14 +88,53 @@ export class Renderer {
             ctx.closePath();
             ctx.fill();
 
-            // Ammo ticks
-            ctx.fillStyle = '#aaffaa';
-            const tickWidth = 3;
-            const gap = 2;
-            const totalWidth = base.ammo * (tickWidth + gap) - gap;
-            const startX = base.x - totalWidth / 2;
-            for (let i = 0; i < base.ammo; i++) {
-                ctx.fillRect(startX + i * (tickWidth + gap), base.y - base.height - 8, tickWidth, 5);
+            // Missiles stacked at the base (like the original arcade game)
+            // Draw up to 10 small missile shapes arranged in rows
+            if (base.ammo > 0) {
+                const missileW = 3;
+                const missileH = 10;
+                const spacing = 5;
+                // Arrange in two rows: bottom row up to 5, top row remainder
+                const bottomCount = Math.min(base.ammo, 5);
+                const topCount = Math.max(0, base.ammo - 5);
+
+                // Bottom row
+                const bottomTotalW = bottomCount * (missileW + spacing) - spacing;
+                const bottomStartX = base.x - bottomTotalW / 2;
+                const bottomY = base.y - 4;
+                for (let i = 0; i < bottomCount; i++) {
+                    const mx = bottomStartX + i * (missileW + spacing);
+                    // Missile body
+                    ctx.fillStyle = '#aaffaa';
+                    ctx.fillRect(mx, bottomY - missileH, missileW, missileH);
+                    // Missile tip
+                    ctx.fillStyle = '#ffffff';
+                    ctx.beginPath();
+                    ctx.moveTo(mx, bottomY - missileH);
+                    ctx.lineTo(mx + missileW / 2, bottomY - missileH - 3);
+                    ctx.lineTo(mx + missileW, bottomY - missileH);
+                    ctx.closePath();
+                    ctx.fill();
+                }
+
+                // Top row
+                if (topCount > 0) {
+                    const topTotalW = topCount * (missileW + spacing) - spacing;
+                    const topStartX = base.x - topTotalW / 2;
+                    const topY = bottomY - missileH - 4;
+                    for (let i = 0; i < topCount; i++) {
+                        const mx = topStartX + i * (missileW + spacing);
+                        ctx.fillStyle = '#aaffaa';
+                        ctx.fillRect(mx, topY - missileH, missileW, missileH);
+                        ctx.fillStyle = '#ffffff';
+                        ctx.beginPath();
+                        ctx.moveTo(mx, topY - missileH);
+                        ctx.lineTo(mx + missileW / 2, topY - missileH - 3);
+                        ctx.lineTo(mx + missileW, topY - missileH);
+                        ctx.closePath();
+                        ctx.fill();
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

- Replace ammo tick marks above bases with stacked missile sprites, matching the original arcade game
- Missiles are arranged in two rows (5 bottom, 5 top) and visually deplete as you fire

## Test plan

- [ ] Start a game and verify missiles are visible at each base
- [ ] Fire missiles and confirm they disappear one by one from the display
- [ ] Empty a base and verify no missiles are shown

https://claude.ai/code/session_01RtqanoCCTH8fxXsVR9sx5h